### PR TITLE
System.Data.SqlClient.SqlException by null property

### DIFF
--- a/DbExecutor/DbExecutor.cs
+++ b/DbExecutor/DbExecutor.cs
@@ -72,7 +72,7 @@ namespace Codeplex.Data
                     Contract.Assume(parameter != null);
                     var param = command.CreateParameter();
                     param.ParameterName = p.Name;
-                    param.Value = p.GetValueDirect(parameter);
+                    param.Value = p.GetValueDirect(parameter) ?? DBNull.Value;
                     command.Parameters.Add(param);
                 }
             }
@@ -85,7 +85,7 @@ namespace Codeplex.Data
                     Contract.Assume(extraParameter != null);
                     var param = command.CreateParameter();
                     param.ParameterName = "__extra__" + p.Name;
-                    param.Value = p.GetValueDirect(extraParameter);
+                    param.Value = p.GetValueDirect(extraParameter) ?? DBNull.Value;
                     command.Parameters.Add(param);
                 }
             }


### PR DESCRIPTION
.SelectやExecuteReaderなどのparameter/ .Insert のinsertItem/ .UpdateのupdateItem などで渡したオブジェクトのフィールドがnullだと System.Data.SqlClient.SqlExceptionが起きるのをDbNull.Valueで迂回。

----
  Message=パラメーター化クエリ '****' に必要なパラメーター '@hoge' が指定されていません。
  Source=.Net SqlClient Data Provider
----

ただ、"select * from table where col=@col"みたいな条件で@colにnullをセットしても "where col is null"とは違うので根本的な解決にはなってない。